### PR TITLE
Add basic OS X support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 2.8)
+project(fusecloop)
+
+include(FindZLIB)
+if (NOT ZLIB_FOUND)
+    message(FATAL_ERROR "ZLIB not found!")
+endif()
+
+file(READ "VERSION" FUSECLOOP_VERSION)
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/strver "\"${FUSECLOOP_VERSION}\"")
+
+include_directories(
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${ZLIB_INCLUDE_DIRS}
+)
+
+add_executable(${PROJECT_NAME}
+    fusecloop.c
+    cloopreader.c
+    cloopreader.h
+    debug.c
+    debug.h
+    common_header.h
+    compressed_loop.h
+)
+
+target_link_libraries(${PROJECT_NAME}
+    ${ZLIB_LIBRARIES}
+)
+
+add_definitions(
+    -Wall
+    -Wextra
+)
+
+if (APPLE)
+    add_definitions(
+        -D_FILE_OFFSET_BITS=64
+    )
+    include_directories(
+        /usr/local/include/osxfuse
+    )
+    target_link_libraries(${PROJECT_NAME}
+        -L/usr/local/lib
+        -losxfuse
+    )
+endif()

--- a/common_header.h
+++ b/common_header.h
@@ -55,7 +55,14 @@ __bswap64(__uint64_t _x)
 #endif /* be64toh */
 #define __be64_to_cpu be64toh
 #else  /* __FreeBSD__ */
+#ifndef __APPLE__
 #include <asm/byteorder.h>
+#else /* __APPLE__ */
+#include <libkern/OSByteOrder.h>
+#define __be64_to_cpu OSSwapBigToHostInt64
+#define __le64_to_cpu OSSwapLittleToHostInt64
+typedef off_t loff_t;
+#endif /* __APPLE__ */
 #include <arpa/inet.h> /* ntohl */
 #endif /* __FreeBSD__ */
 #include "compressed_loop.h"

--- a/fusecloop.c
+++ b/fusecloop.c
@@ -39,7 +39,6 @@
 #include <fuse.h>
 #include <time.h>
 #include <stdio.h>  // for fprintf
-#include <malloc.h> // for malloc
 
 const char* version=
 #include "strver"


### PR DESCRIPTION
Fix compiling with OS X and change functionality so it's listed as a file with "dmg" extension which can be mounted easily in OS X by double-clicking.

However, I have found it unstable still, and can cause the apps to lockup, requiring me to reboot. I've only tested with OS X 10.10 via [Fuse for OS X](https://osxfuse.github.io). I'm not sure which part is unstable, Fuse or fusecloop. I've started making some additional changes I think is necessary, like using `cloop_read_all` instead of `cloop_read` to make sure all data is read for a single read call. This fixed issues I could easily reproduce with a hex editor viewing the Knoppix file (~10GB uncompressed) where reads were not returning all required bytes. However, the hang still exists. I will continue to investigate, but for now these changes are enough to get it functional.